### PR TITLE
More fire

### DIFF
--- a/app/components/Forms.tsx
+++ b/app/components/Forms.tsx
@@ -71,7 +71,7 @@ const Forms = () => {
     },
   ];
   return (
-    <div className="max-w-screen flex flex-col mt-20 justify-center mb-60">
+    <div className="max-w-screen flex flex-col mt-20 justify-center">
       <span className="flex text-4xl justify-center my-10 font-pixelify">
         Sign up as...
       </span>

--- a/app/components/Forms.tsx
+++ b/app/components/Forms.tsx
@@ -101,8 +101,8 @@ const Forms = () => {
           <Image
             src="/tg_logo_yellow.jpg"
             alt="Telegram"
-            width={100}
-            height={100}
+            width={50}
+            height={50}
             className="object-cover object-center w-full rounded-t-m drop-shadow-2xl"
           />
         </a>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,7 +15,7 @@ export default function Home() {
         <Intro />
         <Acts />
       </div>
-      <div className="flex flex-col bg-sunrise-lower bg-cover text-white justify-center">
+      <div className="flex flex-col bg-sunrise-lower bg-[length:100%] bg-no-repeat bg-[#111028] bg-bottom pb-[25vw] text-white justify-center">
         <Partners />
         <Details />
         <Forms />


### PR DESCRIPTION
This pins the background to the bottom, no matter how long the page becomes. The bottom padding based on viewport width ensures that no mater how much the image scales up & down that the campfire has space.

Note: the Telegram logo is above the fire as they're both yellow (just a little different than the design)

fixes #12 